### PR TITLE
V.2.2.1 Update

### DIFF
--- a/io.thenexusavenger.Nexus-LU-Launcher.yml
+++ b/io.thenexusavenger.Nexus-LU-Launcher.yml
@@ -49,5 +49,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/TheNexusAvenger/Nexus-LU-Launcher.git
-        commit: 6af771c141c6992ba270c5891a362d31285cfbda
+        commit: cf7c4477bdeeeca28d52c94d10561ad5d48daed3
       - ./nuget-sources.json


### PR DESCRIPTION
Updates Nexus LU Launcher to V.2.2.1 ([GitHub release](https://github.com/TheNexusAvenger/Nexus-LU-Launcher/releases/tag/V.2.2.1)).