### PR TITLE
V.2.3.0 Update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 build:
-	flatpak install -y org.freedesktop.Sdk//23.08 org.freedesktop.Platform//23.08 org.freedesktop.Sdk.Compat.i386/x86_64/23.08 org.winehq.Wine/x86_64/stable-23.08 org.freedesktop.Sdk.Extension.dotnet8//23.08
+	flatpak install -y org.freedesktop.Sdk//24.08 org.freedesktop.Platform//24.08 org.freedesktop.Sdk.Compat.i386/x86_64/24.08 org.winehq.Wine/x86_64/stable-24.08 org.freedesktop.Sdk.Extension.dotnet9//24.08
 	flatpak-builder --ccache --force-clean build-dir io.thenexusavenger.Nexus-LU-Launcher.yml
 	flatpak-builder --force-clean --user --install build-dir io.thenexusavenger.Nexus-LU-Launcher.yml
 run:

--- a/io.thenexusavenger.Nexus-LU-Launcher.yml
+++ b/io.thenexusavenger.Nexus-LU-Launcher.yml
@@ -1,8 +1,8 @@
 app-id: io.thenexusavenger.Nexus-LU-Launcher
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 base: org.winehq.Wine
-base-version: stable-23.08
+base-version: stable-24.08
 sdk: org.freedesktop.Sdk
 command: Nexus-LU-Launcher
 
@@ -18,11 +18,11 @@ finish-args:
   - --filesystem=~/.steam/debian-installation/logs:ro # Required for the "Steam One-Click" Patch to access the non-Steam games list on Debian-based systems.
   - --filesystem=~/.steam/debian-installation/userdata # Required for the "Steam One-Click" Patch to access the non-Steam games list on Debian-based systems.
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.dotnet8
+  - org.freedesktop.Sdk.Extension.dotnet9
 add-extensions:
   org.freedesktop.Platform.Compat.i386:
     directory: lib/i386-linux-gnu
-    version: '23.08'
+    version: '24.08'
 inherit-extensions:
   - org.freedesktop.Platform.GL32
   - org.freedesktop.Platform.ffmpeg-full
@@ -32,22 +32,22 @@ inherit-extensions:
   - org.winehq.Wine.DLLs
 
 build-options:
-  append-path: /usr/lib/sdk/dotnet8/bin
-  append-ld-library-path: /usr/lib/sdk/dotnet8/lib
-  append-pkg-config-path: /usr/lib/sdk/dotnet8/lib/pkgconfig
+  append-path: /usr/lib/sdk/dotnet9/bin
+  append-ld-library-path: /usr/lib/sdk/dotnet9/lib
+  append-pkg-config-path: /usr/lib/sdk/dotnet9/lib/pkgconfig
 
 modules:
   - name: Nexus-LU-Launcher
     buildsystem: simple
     build-commands:
       - dotnet publish -c release -r linux-x64 --source ./nuget-sources
-      - cp ./Nexus.LU.Launcher.Gui/bin/Release/net8.0/linux-x64/publish/* /app/bin/
+      - cp ./Nexus.LU.Launcher.Gui/bin/Release/net9.0/linux-x64/publish/* /app/bin/
       - mv /app/bin/Nexus.LU.Launcher.Gui /app/bin/Nexus-LU-Launcher
-      - install -Dm644 ./packaging/Flatpak/DesktopEntry.desktop /app/share/applications/${FLATPAK_ID}.desktop
-      - install -Dm644 ./packaging/Flatpak/Icon.png /app/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.png
-      - install -Dm644 ./packaging/Flatpak/Metainfo.xml /app/share/metainfo/io.thenexusavenger.Nexus-LU-Launcher.metainfo.xml
+      - install -Dm644 ./packaging/Flatpak/DesktopEntry.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
+      - install -Dm644 ./packaging/Flatpak/Icon.png ${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.png
+      - install -Dm644 ./packaging/Flatpak/Metainfo.xml ${FLATPAK_DEST}/share/metainfo/io.thenexusavenger.Nexus-LU-Launcher.metainfo.xml
     sources:
       - type: git
         url: https://github.com/TheNexusAvenger/Nexus-LU-Launcher.git
-        commit: cf7c4477bdeeeca28d52c94d10561ad5d48daed3
+        commit: 487a377608fcf1240f134376cd55cfb19cfc0405
       - ./nuget-sources.json

--- a/nuget-sources.json
+++ b/nuget-sources.json
@@ -1,17 +1,17 @@
 [
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia/11.0.9/avalonia.11.0.9.nupkg",
-        "sha512": "7cb403dc4fd27408644912eb138330ad309fba4e379c2d196fcb85c7d87b83275e86d2518543ec68fe42fb1dce76cc676f05ea24f90ac33b715951e66f2aff0d",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia/11.2.3/avalonia.11.2.3.nupkg",
+        "sha512": "3e1c9a278588d40820b0230762b16ec138c9a94b376d4da5069ec6b9d1bad472f2b47af1d26f4da1507360e66be130edb3b1da057874863f1a9b4dd3acce7911",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.11.0.9.nupkg"
+        "dest-filename": "avalonia.11.2.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.angle.windows.natives/2.1.0.2023020321/avalonia.angle.windows.natives.2.1.0.2023020321.nupkg",
-        "sha512": "4ec227f1c4da9cffbcccf2273171b51792c52f3e83f2a808904c559563a73f0ad63e6199c5fd82474101e03ac10718aab1877c1b4b051cf80d3ed88d41de7d06",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.angle.windows.natives/2.1.22045.20230930/avalonia.angle.windows.natives.2.1.22045.20230930.nupkg",
+        "sha512": "82bb927cff47738cd13ee87f93664eed203fe0586c807c0fb2215e743b01d787c1ab8285512c82a3f891dbd303a20eb1feb24fdfe09a9edd91d9de65ce96f4d7",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.angle.windows.natives.2.1.0.2023020321.nupkg"
+        "dest-filename": "avalonia.angle.windows.natives.2.1.22045.20230930.nupkg"
     },
     {
         "type": "file",
@@ -22,94 +22,94 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.desktop/11.0.9/avalonia.desktop.11.0.9.nupkg",
-        "sha512": "f046d6eddadce2dc9d59a382652200cb1d816ca383b4179f5ea5f2be98fccf72397e312ec22e2f90d0800916ae7cad725b5723ec7fb32f5ac26accc0887f3b1c",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.desktop/11.2.3/avalonia.desktop.11.2.3.nupkg",
+        "sha512": "d4571946343ea7c19cf5ea7ed4dc9996eb6143522a043ee08910e12522646af63e75bae77d9fd58bf2231d58c4fc4a0e46d1f7b7fa4b9a4ff57e92a1e1de9bdf",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.desktop.11.0.9.nupkg"
+        "dest-filename": "avalonia.desktop.11.2.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.freedesktop/11.0.9/avalonia.freedesktop.11.0.9.nupkg",
-        "sha512": "4281a33f3c1bc12b3aeee101bff8504970c6ee40c8fb420c524964f0cb4715a725b4fdc3df3e3bc9843dacfe8e386710d7c9e194fd2cf0520b3876a311ac9123",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.freedesktop/11.2.3/avalonia.freedesktop.11.2.3.nupkg",
+        "sha512": "5b2ca181dcfeb768ea9bf3ece7a445b4b0f80bbd54c2c36355bdde8a842c5f1385ae6896ccca1898bd01d43cc08c7b2a4ebfb0ca2204c21e681c69de849a1ace",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.freedesktop.11.0.9.nupkg"
+        "dest-filename": "avalonia.freedesktop.11.2.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.native/11.0.9/avalonia.native.11.0.9.nupkg",
-        "sha512": "5625c7c51bfc18ec4224c4658930e492f664dd6749df6fc63b816d50d540988a741b0d8001c3c647b8445438b8c04f89cd77e20c8e219b16cc608d7d2110ced2",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.native/11.2.3/avalonia.native.11.2.3.nupkg",
+        "sha512": "55b82bb16653841002bd1f6ad45e90c945c0b92976df7e5b4c6aa7dfe96aae18a2798c38f3e23b2586bc29c799912362d010233d29db9caa24c5f75fc2d6eeba",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.native.11.0.9.nupkg"
+        "dest-filename": "avalonia.native.11.2.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.remote.protocol/11.0.9/avalonia.remote.protocol.11.0.9.nupkg",
-        "sha512": "381d56df9d70b432e2c7484347ecc4c694fd0150d9264fd61163c2e29ff62ea8e90ac546e68d1ee040cf5cc06bd7688f49e6c9291ee354e5acf05f0bc88f979e",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.remote.protocol/11.2.3/avalonia.remote.protocol.11.2.3.nupkg",
+        "sha512": "94f5a03b3810a1c6df15e5f1c6bd95b32b99d13856e0270834e15cf0846966e6f3ed8175d7cad59723a1d00a0a11e4097eaf015597a95096728e5f9a2fd6443a",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.remote.protocol.11.0.9.nupkg"
+        "dest-filename": "avalonia.remote.protocol.11.2.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.skia/11.0.9/avalonia.skia.11.0.9.nupkg",
-        "sha512": "1154146b28bb630c2bf3c34968c0c0f6ef043b3a961bd1c81d263e92fbea90d8370e170b38741d81604df42704eabf5f63b8336282cc2ab83f143a045b00fda6",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.skia/11.2.3/avalonia.skia.11.2.3.nupkg",
+        "sha512": "3a1fb97d0b24b774e464313d11bca01d05d06072e9642d65ff356e1a6d87dff7c1a067a64b0098a23e5e6a9fa26d837f2a5ba0aa144afa10e4542597eb07262b",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.skia.11.0.9.nupkg"
+        "dest-filename": "avalonia.skia.11.2.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.themes.simple/11.0.9/avalonia.themes.simple.11.0.9.nupkg",
-        "sha512": "9738da934d9f3ccfe0b61a20f1ff09b449bed9c7fc9c7e6d5d063b24672341d1e42cf1b10aa2e069b1b7bbeacb158b1a0b96d55b3858622702358b833e14ae9f",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.themes.simple/11.2.3/avalonia.themes.simple.11.2.3.nupkg",
+        "sha512": "db2ee573a40fdf69c2967139db5c6e1b33fc1a241f5c4578d9583b4c2b2fd1fa0c6ae61e6c30f93289331d4e120701f1caeef19b6a7c133f4cd82f9fbf777cc8",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.themes.simple.11.0.9.nupkg"
+        "dest-filename": "avalonia.themes.simple.11.2.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.win32/11.0.9/avalonia.win32.11.0.9.nupkg",
-        "sha512": "6ffbd22fd8508a547cd4d3671cf39342788095c9f4ca972d8a93a52e4854f7774476a98436dbae1f1401026c408ea3c1f5f485e1e6544231bc611b8abefb6906",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.win32/11.2.3/avalonia.win32.11.2.3.nupkg",
+        "sha512": "1a163f2342ec1f5de731ebeca8598735f0b4c236ec4dbd68056b8f9665206ba631e795e779147285f32b2165b5704a53221244137b0dae156f7302b3eaeb50ae",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.win32.11.0.9.nupkg"
+        "dest-filename": "avalonia.win32.11.2.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.x11/11.0.9/avalonia.x11.11.0.9.nupkg",
-        "sha512": "b4562ddc4952a3852a486d5313e54f20327df23b82e14c51f7d3a7be79934b3eeb48a42461789abfb8e23eb5918ecbc82107d792bad3f0aac05cbfc3553a1e28",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.x11/11.2.3/avalonia.x11.11.2.3.nupkg",
+        "sha512": "cbac07377f5c424fcc49ee8ebfd0b128d7411825dfefc66164644673c8fd1dfd4ed00b510a06bd990c6cbd22cbdf7cc57f7ae35e84f9fdab57d6a08ce089f0b9",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.x11.11.0.9.nupkg"
+        "dest-filename": "avalonia.x11.11.2.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp/7.3.0/harfbuzzsharp.7.3.0.nupkg",
-        "sha512": "5d1887b3cdc22334132f8fff8b2ac1f57cb54e9fcd25d21d32f8f86c7c694e86739c067e8b1ae3da10c1b1b3417f27b640b0e7890101ee2d420fba3feba580b5",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp/7.3.0.3/harfbuzzsharp.7.3.0.3.nupkg",
+        "sha512": "bed625c58228c404f860fb3e247fb6ca3209c93fea62da498ba43419500bd40944b2e117f50f587f860101a6c6478ad1d18075f655376d1749d238d74b6a0bd3",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.7.3.0.nupkg"
+        "dest-filename": "harfbuzzsharp.7.3.0.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.linux/7.3.0/harfbuzzsharp.nativeassets.linux.7.3.0.nupkg",
-        "sha512": "48a4bf98b9f59181ef1885a3d4d3ee605b63aeab3b49248a3e49a6bbbdcdae4bcb974073492319789f17eb92edebc1ddf050c5d0724eddc5ea3277d5c2054731",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.linux/7.3.0.3/harfbuzzsharp.nativeassets.linux.7.3.0.3.nupkg",
+        "sha512": "cf94e5693c4c475a702c342163f1ee28d2d9c3a13939a8334bb7133d13ffc5ed95d9dbb6145e7ac004cfd6e626a16280df7f1a4c7e3687569eced58b8890a1b5",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.linux.7.3.0.nupkg"
+        "dest-filename": "harfbuzzsharp.nativeassets.linux.7.3.0.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.macos/7.3.0/harfbuzzsharp.nativeassets.macos.7.3.0.nupkg",
-        "sha512": "803ace4c95a3ae0c69e30003d3f6dc1b409ff0390b94c37d8dbc1a5321dca74b5d7b2a8aefaab0a792cd47d4e3c2d24e733ed313e0597d80a7ef81b67bc413ee",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.macos/7.3.0.3/harfbuzzsharp.nativeassets.macos.7.3.0.3.nupkg",
+        "sha512": "a6dac2eb2c536f25734e5358aaae9263f568871fa31169e816d8617c5b6e933d78e2956ea9e01ac37e0022bf243e63124956804b46f6a0d00826aa02320ef22b",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.macos.7.3.0.nupkg"
+        "dest-filename": "harfbuzzsharp.nativeassets.macos.7.3.0.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.webassembly/7.3.0/harfbuzzsharp.nativeassets.webassembly.7.3.0.nupkg",
-        "sha512": "eb0925b18271e435f1b90fabbefef4d01bf4d1443628509f66b4f4ecf8603bba91abac29b3b19a09170f491986c89d7a37d43f854d15379d9e74b27cbad6fae8",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.webassembly/7.3.0.3/harfbuzzsharp.nativeassets.webassembly.7.3.0.3.nupkg",
+        "sha512": "87ad62fc8471b12ecce7284ff8f69fe681ae1010e6e44e6ac66807b061213d8b8f5537ff4fe34195107c6ba1bc3bff1c2db0abe7bd51520820e7b6f2addfdf63",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.webassembly.7.3.0.nupkg"
+        "dest-filename": "harfbuzzsharp.nativeassets.webassembly.7.3.0.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.win32/7.3.0/harfbuzzsharp.nativeassets.win32.7.3.0.nupkg",
-        "sha512": "3f477b5cb4d70df1333f69272c885c31dc43118ebf4edc990ae6ea8f29db0a3d4886a74b6d7ad2778d1db6bf7660bf0ae0eb23030c0b9c65710c5baa2389b00c",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.win32/7.3.0.3/harfbuzzsharp.nativeassets.win32.7.3.0.3.nupkg",
+        "sha512": "dd940d3b3085996b4e5961a0e42bb1a86daad360e3377602fafd60b0cb4d3d5ed9c3f4293a8551df75f38111b3a9f4dbbea4cb27b3e0632a6d48239b606d13c9",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.win32.7.3.0.nupkg"
+        "dest-filename": "harfbuzzsharp.nativeassets.win32.7.3.0.3.nupkg"
     },
     {
         "type": "file",
@@ -120,142 +120,135 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/8.0.2/microsoft.aspnetcore.app.runtime.linux-x64.8.0.2.nupkg",
-        "sha512": "8d4fb5191b7d55b33bb517768d5d57b9271c191ec9fa634265cf9fb2313a2282a48d7f1d96fbe6f8cc5a05f534db31300f7b6f166b9d55af68982d82f80b060b",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/9.0.0/microsoft.aspnetcore.app.runtime.linux-x64.9.0.0.nupkg",
+        "sha512": "6a1d62af51047864ac8630242a9f257dd978e163985c566673276f3919d022cdc878a0a4c2141364d92064ec22793d4db460744cb6dcd21d45495eac511967b9",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.8.0.2.nupkg"
+        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.9.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.dotnet.ilcompiler/8.0.2/microsoft.dotnet.ilcompiler.8.0.2.nupkg",
-        "sha512": "bf5833d8a977eef10c02b126644f8fa3994cfd6f495583a7c499ae3fd64767ba0cc2ff3df6a447e217ed82abf1c326437c095eabac613da11a2f26efd1a798e8",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.dotnet.ilcompiler/9.0.0/microsoft.dotnet.ilcompiler.9.0.0.nupkg",
+        "sha512": "5655e96822f8fd906ad6f956ff9f1bc26f6135dd8c5d18b03d786f7dc96c2cc2768fa7c969a5f60260775ec80859895a81e5b4158d6ff909b286b21f98a246c6",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.dotnet.ilcompiler.8.0.2.nupkg"
+        "dest-filename": "microsoft.dotnet.ilcompiler.9.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging.abstractions/7.0.0/microsoft.extensions.logging.abstractions.7.0.0.nupkg",
-        "sha512": "8f648f6f9e11e2ddd6a2a963e95e6f40fb71fb152bdcb5685c2688d305df037994a2c88a580dbb85720f79eb63c91d671c5369a24268c3f7e6e141accfb91b45",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection.abstractions/8.0.1/microsoft.extensions.dependencyinjection.abstractions.8.0.1.nupkg",
+        "sha512": "8118da9932da382b1c22379f9169bea93cabcf17f5d56c1b6616fae23b1bf14b4a38539b7f8417f63f161b14021f2634df9e4f9fa62f5fc84667018a1d92c967",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.extensions.logging.abstractions.7.0.0.nupkg"
+        "dest-filename": "microsoft.extensions.dependencyinjection.abstractions.8.0.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.net.illink.tasks/8.0.2/microsoft.net.illink.tasks.8.0.2.nupkg",
-        "sha512": "ec26acbacf83cfff8e5154854cf3c23585775fd41a844ddc0046afbac4954ca1535789ea302ce698f1d074ed2f938890c35a0f48a6631159f8369675600fd41e",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging.abstractions/8.0.1/microsoft.extensions.logging.abstractions.8.0.1.nupkg",
+        "sha512": "c8e0fdb230e0133f2e3e2f84f300258f4348fc34af23ce597cf12446e0e91711cb4d4d0fef3333de3ac23a49e006a9eef36baf95d2b5b7449c3d755a6d55c045",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.net.illink.tasks.8.0.2.nupkg"
+        "dest-filename": "microsoft.extensions.logging.abstractions.8.0.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.win-x64/8.0.2/microsoft.netcore.app.host.win-x64.8.0.2.nupkg",
-        "sha512": "2d251532075fa30e7199cd1817b0a9ccfad879323873c340339f769543db706842245715e3aab7716f8f90ff25f5a74649d8c94c30ce2f6faf63a04aa448df4a",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.net.illink.tasks/9.0.0/microsoft.net.illink.tasks.9.0.0.nupkg",
+        "sha512": "c60d7deae05f9d498995ce5a8b37d38b9f3c332aee23d1e5bdaaa3de631bc7527d19fa45fadde075647ab8a6c7d25556f68c7327b1605fb356644663df78f46a",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.host.win-x64.8.0.2.nupkg"
+        "dest-filename": "microsoft.net.illink.tasks.9.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/8.0.2/microsoft.netcore.app.runtime.linux-x64.8.0.2.nupkg",
-        "sha512": "b775efc75d7bdd3b9e29811b651ed2fdef888367e69472f06bca0829435375dddf78ad1faec73edd9d65d59118c24acae4cbc7cf45b555b6c0f669cc99ac8be1",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.win-x64/9.0.0/microsoft.netcore.app.host.win-x64.9.0.0.nupkg",
+        "sha512": "ed2107bef0cf698856c8d85402ead9a2ed683eb4e089b9f693d4415be7da9529665cfab9008a8d8b810e0c951bc9d735432c83daf423455817be117a689f6cd5",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.runtime.linux-x64.8.0.2.nupkg"
+        "dest-filename": "microsoft.netcore.app.host.win-x64.9.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/nexus.logging/1.2.0/nexus.logging.1.2.0.nupkg",
-        "sha512": "46510447b6e0e75023598606e29591d3f4172a9f4a3ce61612b7cf35f544c467fc23859dff1c0d759d25e1ee9f236761623c3857e6c9aaa062566b5ca67e0bb3",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/9.0.0/microsoft.netcore.app.runtime.linux-x64.9.0.0.nupkg",
+        "sha512": "b53da3f97f2c6899fd27ede233a328270bf99040215b2bb03de6598a9ab6eba603225c04696d850e3a160892552c2def08389d1e59d34fa20a52ffcb30a2a958",
         "dest": "nuget-sources",
-        "dest-filename": "nexus.logging.1.2.0.nupkg"
+        "dest-filename": "microsoft.netcore.app.runtime.linux-x64.9.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.linux-x64.microsoft.dotnet.ilcompiler/8.0.2/runtime.linux-x64.microsoft.dotnet.ilcompiler.8.0.2.nupkg",
-        "sha512": "3ac598c196fbebebfa891f8a8463fe01510f0c408f9b9182a4bca431a1ecb2f42ea8758403ed1e1a8d87272e519b1b7d6e866ac01e98c34591c71fa999658648",
+        "url": "https://api.nuget.org/v3-flatcontainer/nexus.logging/1.3.0/nexus.logging.1.3.0.nupkg",
+        "sha512": "2a9b2b726e64aba05e897cf4e7a2a26899793d2e39a99fa7b069ef52d7ca06647cd4ac6c587fd0b1562c89f46d7b4511d8d1d39f2b0856745f75e06e39592af9",
         "dest": "nuget-sources",
-        "dest-filename": "runtime.linux-x64.microsoft.dotnet.ilcompiler.8.0.2.nupkg"
+        "dest-filename": "nexus.logging.1.3.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.win-x64.microsoft.dotnet.ilcompiler/8.0.2/runtime.win-x64.microsoft.dotnet.ilcompiler.8.0.2.nupkg",
-        "sha512": "018dce7702644676f9b6ff24d2787f7dfcf31f2bc1d79b727b84e0be019770f7b227e320b7eabb6d0c94217e87ba79e478ed5e3c8ffb99d7cf90b756942803af",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.linux-x64.microsoft.dotnet.ilcompiler/9.0.0/runtime.linux-x64.microsoft.dotnet.ilcompiler.9.0.0.nupkg",
+        "sha512": "9bdad0c876bc93ab661bd655d89c9762a1bca35804170f2e87c98fee544a59eb40d5c7978cf7d9504c0a0573316beef8f46d842e26cbebde982f6618f99f82d0",
         "dest": "nuget-sources",
-        "dest-filename": "runtime.win-x64.microsoft.dotnet.ilcompiler.8.0.2.nupkg"
+        "dest-filename": "runtime.linux-x64.microsoft.dotnet.ilcompiler.9.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/sharpcompress/0.36.0/sharpcompress.0.36.0.nupkg",
-        "sha512": "0fe8ecabc685498ff3226b6b1599520edc19151df8fa4b22f29916df8761d8c45590b0298a3c5e382d39b2b0202272d60b83a9de818b083cb57bc7ecbc2b7690",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.win-x64.microsoft.dotnet.ilcompiler/9.0.0/runtime.win-x64.microsoft.dotnet.ilcompiler.9.0.0.nupkg",
+        "sha512": "3f9f5a47d543f468c8ece34000ad525631097d91090a92c5a3d0952def2b691766ab531683f790d6c5d1d80479d063e672248206922af2b0c06192ec0a22f1eb",
         "dest": "nuget-sources",
-        "dest-filename": "sharpcompress.0.36.0.nupkg"
+        "dest-filename": "runtime.win-x64.microsoft.dotnet.ilcompiler.9.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp/2.88.7/skiasharp.2.88.7.nupkg",
-        "sha512": "4a54db99f245742231c208c455b6f29a96ee79672e3eab7f7dbd6b352aeaa3b6a87d6946017d899887b4026d5b4ceca6297230dbaacf1725a9726f796ee72303",
+        "url": "https://api.nuget.org/v3-flatcontainer/sharpcompress/0.38.0/sharpcompress.0.38.0.nupkg",
+        "sha512": "9107c6cf7b5d0633a31496634c388e41870e5f25a99c4eaa44f0bb5e1ffa24307c186ef63e6b54983571cde9f0558a44f51c6b743943162668beb6dadd438278",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.2.88.7.nupkg"
+        "dest-filename": "sharpcompress.0.38.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.linux/2.88.7/skiasharp.nativeassets.linux.2.88.7.nupkg",
-        "sha512": "4f7db81ee10c07db2d824813dacf0189bafd0e30dcb3087ffebfab9927976f67c2cde71c1a22345718d83fa32193303cf9d578e7d9d6fa30964ca1bf8c8127d7",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp/2.88.9/skiasharp.2.88.9.nupkg",
+        "sha512": "3a2ffa5e05f45cdb80e6735ee947e91e08ff145fc50c7882e75d44b6ae0c2cd733420d15b6a4274a186b3a79d463a1273e27ff7fd79a51d0937251ebb6ef761d",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.linux.2.88.7.nupkg"
+        "dest-filename": "skiasharp.2.88.9.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.macos/2.88.7/skiasharp.nativeassets.macos.2.88.7.nupkg",
-        "sha512": "52ce6db283f366aa8f469f80564586c4d09fdbdbc4442fe24bf159fca803b92bdf2e209f537f9b30948a289e063fced46232b44a5c686168e33322e6314f1d5e",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.linux/2.88.9/skiasharp.nativeassets.linux.2.88.9.nupkg",
+        "sha512": "5c6a3e93a18e70e6adcd548bd2f76fa311114346ce4d812e520f250d33342d5ad8d05ea285433bd15cb19bbc48d9bbf2ef7d1f1725dd71705accefaba3f46892",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.macos.2.88.7.nupkg"
+        "dest-filename": "skiasharp.nativeassets.linux.2.88.9.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.webassembly/2.88.7/skiasharp.nativeassets.webassembly.2.88.7.nupkg",
-        "sha512": "bee40d258b80a0ea1e849d77c8fd7d594643ac24c666aa9575473462009cdfd1c33e1d4148848187bebc239ced3eb37652b3c7558a597c6959604aabf44498a4",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.macos/2.88.9/skiasharp.nativeassets.macos.2.88.9.nupkg",
+        "sha512": "74cfb865746f2911935290bfb92469b331e50415d5abeda87598ebdb4049c52af84a5daeda41ebcb0bbaec6a7debb42d83cdc6c9f61cea55d43c720a78c3ebce",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.webassembly.2.88.7.nupkg"
+        "dest-filename": "skiasharp.nativeassets.macos.2.88.9.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.win32/2.88.7/skiasharp.nativeassets.win32.2.88.7.nupkg",
-        "sha512": "3476a2b19745b1ece35858a8534a02f7196ea0b30971d96b4d6219d2e8de4068f9ad83b5e0527519facd88fc64b46c69ac43b45a0f26c01e36885c3c54872324",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.webassembly/2.88.9/skiasharp.nativeassets.webassembly.2.88.9.nupkg",
+        "sha512": "c1815d86904c25e1bc3e43b22cc4b2db0ec931c13dd4d9505a2b6cb0ca1d24329f725bce650af1b0dc12bc70d8352cc19f2ac452aab462e7af4787d4601e0e0a",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.win32.2.88.7.nupkg"
+        "dest-filename": "skiasharp.nativeassets.webassembly.2.88.9.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.componentmodel.annotations/4.5.0/system.componentmodel.annotations.4.5.0.nupkg",
-        "sha512": "7f5029507196abf9490bc3d913b26a6c0ded898ed99e06503b699b61f086d0995055552aaa654c032d1f32f03012e1badfd338ec42dd3fa3d0c5ce4e228ea2e8",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.win32/2.88.9/skiasharp.nativeassets.win32.2.88.9.nupkg",
+        "sha512": "d18bd8194041c7ffb79302d4f1be584e8c024e88b12cb4669a738cae551da3d3e3924087bb0aa42d34a9003cfb35037d73637894e67d02223d100a1b4215eeec",
         "dest": "nuget-sources",
-        "dest-filename": "system.componentmodel.annotations.4.5.0.nupkg"
+        "dest-filename": "skiasharp.nativeassets.win32.2.88.9.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.pipelines/6.0.0/system.io.pipelines.6.0.0.nupkg",
-        "sha512": "c5983b4510bc8ae4116133ffb9b280fe61d99d47ef52dd78e5bfd03e090901896d5d5fd738dae57006b971840a4d9422bded33ddefa5e927d75d309ef1f70dea",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.io.pipelines/8.0.0/system.io.pipelines.8.0.0.nupkg",
+        "sha512": "57eb6a11e84f40a48b57b1dc5786a01aa9852122b7d15363490d8a12c9a458bf99a8ddf4c0c0247be98559c2b42e769a10bda2c5a9817735484d960dc652eb12",
         "dest": "nuget-sources",
-        "dest-filename": "system.io.pipelines.6.0.0.nupkg"
+        "dest-filename": "system.io.pipelines.8.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.numerics.vectors/4.5.0/system.numerics.vectors.4.5.0.nupkg",
-        "sha512": "9c04ec0530f608aaf801837a791b33857e2ca6d2265a6049c01fd4e972825967e709cad3070f174829b7400f608e9a641d3afc3a45d4636d4c47dd43dd0657b3",
+        "url": "https://api.nuget.org/v3-flatcontainer/tmds.dbus.protocol/0.20.0/tmds.dbus.protocol.0.20.0.nupkg",
+        "sha512": "602cf251f034d41a4feef63f0d77c3005553f88abd5ba9cf941d0f731369aa1c0a8844e89686f7fd3a1ad8e02068b5c3b4dd3e719fdb40cb603b9ca3b0e22e8e",
         "dest": "nuget-sources",
-        "dest-filename": "system.numerics.vectors.4.5.0.nupkg"
+        "dest-filename": "tmds.dbus.protocol.0.20.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/tmds.dbus.protocol/0.15.0/tmds.dbus.protocol.0.15.0.nupkg",
-        "sha512": "45958a88536d1daa769934986b3ac514cdc1104a936bc404dbdec550c958847e7408af621350c09fa51bc4b837fb88471ec6e6056c4aaa2cebf30f044cd834e9",
+        "url": "https://api.nuget.org/v3-flatcontainer/zstdsharp.port/0.8.1/zstdsharp.port.0.8.1.nupkg",
+        "sha512": "b1efdf27e2c4ef13387695318701d2f0344e4195b364cb373061766dc8269d7276adc0a2282c80d900e987bb2812b62884725878409abeeba5f796cd81395d85",
         "dest": "nuget-sources",
-        "dest-filename": "tmds.dbus.protocol.0.15.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/zstdsharp.port/0.7.4/zstdsharp.port.0.7.4.nupkg",
-        "sha512": "6931f1d35f7dec666e1061483fe70646615281163ed2731e335e36b7cbfd71a29fc548837d5de5d7b322bd4f2e5a73f7e2186312ff0a13a013f2404a0d7958b0",
-        "dest": "nuget-sources",
-        "dest-filename": "zstdsharp.port.0.7.4.nupkg"
+        "dest-filename": "zstdsharp.port.0.8.1.nupkg"
     }
 ]

--- a/update-sources.py
+++ b/update-sources.py
@@ -38,4 +38,4 @@ if not os.path.exists(repositoryPath):
     subprocess.Popen(["git", "reset", "--hard", commit], cwd=repositoryPath).wait()
 
 # Run the script.
-subprocess.Popen(["python3", generatorFilePath, "--freedesktop", freedesktopVersion, "--dotnet", dotnetVersion, "--runtime", "linux-x64", "nuget-sources.json", os.path.join(repositoryPath, "Nexus.LU.Launcher.Gui", "Nexus.LU.Launcher.Gui.csproj")]).wait()
+subprocess.Popen(["python3", generatorFilePath, "nuget-sources.json", os.path.join(repositoryPath, "Nexus.LU.Launcher.Gui", "Nexus.LU.Launcher.Gui.csproj"), "--freedesktop", freedesktopVersion, "--dotnet", dotnetVersion, "--runtime", "linux-x64"]).wait()


### PR DESCRIPTION
Updates Nexus LU Launcher to V.2.3.0 ([GitHub release](https://github.com/TheNexusAvenger/Nexus-LU-Launcher/releases/tag/V.2.3.0)).