### PR TITLE
V.2.3.1 Update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 build:
-	flatpak install -y org.freedesktop.Sdk//24.08 org.freedesktop.Platform//24.08 org.freedesktop.Sdk.Compat.i386/x86_64/24.08 org.winehq.Wine/x86_64/stable-24.08 org.freedesktop.Sdk.Extension.dotnet9//24.08
+	flatpak install -y org.freedesktop.Sdk//25.08 org.freedesktop.Platform//25.08 org.freedesktop.Sdk.Compat.i386/x86_64/25.08 org.winehq.Wine/x86_64/stable-25.08 org.freedesktop.Sdk.Extension.dotnet9//25.08
 	flatpak-builder --ccache --force-clean build-dir io.thenexusavenger.Nexus-LU-Launcher.yml
 	flatpak-builder --force-clean --user --install build-dir io.thenexusavenger.Nexus-LU-Launcher.yml
 run:

--- a/io.thenexusavenger.Nexus-LU-Launcher.yml
+++ b/io.thenexusavenger.Nexus-LU-Launcher.yml
@@ -1,8 +1,8 @@
 app-id: io.thenexusavenger.Nexus-LU-Launcher
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 base: org.winehq.Wine
-base-version: stable-24.08
+base-version: stable-25.08
 sdk: org.freedesktop.Sdk
 command: Nexus-LU-Launcher
 
@@ -22,7 +22,7 @@ sdk-extensions:
 add-extensions:
   org.freedesktop.Platform.Compat.i386:
     directory: lib/i386-linux-gnu
-    version: '24.08'
+    version: '25.08'
 inherit-extensions:
   - org.freedesktop.Platform.GL32
   - org.freedesktop.Platform.ffmpeg-full
@@ -49,5 +49,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/TheNexusAvenger/Nexus-LU-Launcher.git
-        commit: 487a377608fcf1240f134376cd55cfb19cfc0405
+        commit: e38eaca96cbf208c73cd1e97cfb2684356abf19a
       - ./nuget-sources.json

--- a/io.thenexusavenger.Nexus-LU-Launcher.yml
+++ b/io.thenexusavenger.Nexus-LU-Launcher.yml
@@ -1,5 +1,6 @@
 app-id: io.thenexusavenger.Nexus-LU-Launcher
-runtime: org.freedesktop.Platformruntime-version: '25.08'
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
 base: org.winehq.Wine
 base-version: stable-25.08
 sdk: org.freedesktop.Sdk
@@ -43,5 +44,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/TheNexusAvenger/Nexus-LU-Launcher.git
-        commit: e38eaca96cbf208c73cd1e97cfb2684356abf19a
+        commit: e38eaca96cbf208c73cd1e97cfb2684356abf19a commit: 487a377608fcf1240f134376cd55cfb19cfc0405
       - ./nuget-sources.json

--- a/io.thenexusavenger.Nexus-LU-Launcher.yml
+++ b/io.thenexusavenger.Nexus-LU-Launcher.yml
@@ -44,5 +44,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/TheNexusAvenger/Nexus-LU-Launcher.git
-        commit: e38eaca96cbf208c73cd1e97cfb2684356abf19a commit: 487a377608fcf1240f134376cd55cfb19cfc0405
+        commit: e38eaca96cbf208c73cd1e97cfb2684356abf19a
       - ./nuget-sources.json

--- a/io.thenexusavenger.Nexus-LU-Launcher.yml
+++ b/io.thenexusavenger.Nexus-LU-Launcher.yml
@@ -1,6 +1,5 @@
 app-id: io.thenexusavenger.Nexus-LU-Launcher
-runtime: org.freedesktop.Platform
-runtime-version: '25.08'
+runtime: org.freedesktop.Platformruntime-version: '25.08'
 base: org.winehq.Wine
 base-version: stable-25.08
 sdk: org.freedesktop.Sdk
@@ -19,12 +18,10 @@ finish-args:
   - --filesystem=~/.steam/debian-installation/userdata # Required for the "Steam One-Click" Patch to access the non-Steam games list on Debian-based systems.
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.dotnet9
-add-extensions:
-  org.freedesktop.Platform.Compat.i386:
-    directory: lib/i386-linux-gnu
-    version: '25.08'
 inherit-extensions:
+  - org.freedesktop.Platform.Compat.i386
   - org.freedesktop.Platform.GL32
+  - org.freedesktop.Platform.codecs_extra.i386
   - org.winehq.Wine.gecko
   - org.winehq.Wine.mono
 

--- a/io.thenexusavenger.Nexus-LU-Launcher.yml
+++ b/io.thenexusavenger.Nexus-LU-Launcher.yml
@@ -27,7 +27,6 @@ inherit-extensions:
   - org.freedesktop.Platform.GL32
   - org.winehq.Wine.gecko
   - org.winehq.Wine.mono
-  - org.winehq.Wine.DLLs
 
 build-options:
   append-path: /usr/lib/sdk/dotnet9/bin

--- a/io.thenexusavenger.Nexus-LU-Launcher.yml
+++ b/io.thenexusavenger.Nexus-LU-Launcher.yml
@@ -25,8 +25,6 @@ add-extensions:
     version: '25.08'
 inherit-extensions:
   - org.freedesktop.Platform.GL32
-  - org.freedesktop.Platform.ffmpeg-full
-  - org.freedesktop.Platform.ffmpeg_full.i386
   - org.winehq.Wine.gecko
   - org.winehq.Wine.mono
   - org.winehq.Wine.DLLs

--- a/nuget-sources.json
+++ b/nuget-sources.json
@@ -1,115 +1,115 @@
 [
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia/11.2.3/avalonia.11.2.3.nupkg",
-        "sha512": "3e1c9a278588d40820b0230762b16ec138c9a94b376d4da5069ec6b9d1bad472f2b47af1d26f4da1507360e66be130edb3b1da057874863f1a9b4dd3acce7911",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia/11.3.12/avalonia.11.3.12.nupkg",
+        "sha512": "041d09867d9dec7c74599d45a23336c3af4622bf491c92080ea309ebf9df8ec68ab97cb85b789328636911bfa9d6c6c08d963ffac9ed86478544d1597de2615e",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.11.2.3.nupkg"
+        "dest-filename": "avalonia.11.3.12.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.angle.windows.natives/2.1.22045.20230930/avalonia.angle.windows.natives.2.1.22045.20230930.nupkg",
-        "sha512": "82bb927cff47738cd13ee87f93664eed203fe0586c807c0fb2215e743b01d787c1ab8285512c82a3f891dbd303a20eb1feb24fdfe09a9edd91d9de65ce96f4d7",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.angle.windows.natives/2.1.25547.20250602/avalonia.angle.windows.natives.2.1.25547.20250602.nupkg",
+        "sha512": "5cf4ba739c4fe0bf9e36ad2b4d481338239ea98216e6188f8c2f7af5efbdcb8926ce7d6af2df951071f8d9294d4d25ce1e52835f2bf4ac08c3dceba5e503ae60",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.angle.windows.natives.2.1.22045.20230930.nupkg"
+        "dest-filename": "avalonia.angle.windows.natives.2.1.25547.20250602.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.buildservices/0.0.29/avalonia.buildservices.0.0.29.nupkg",
-        "sha512": "9485e64c84b087beaf0803c049e9c057216b889bb8d452f0339149dbde65b2c9f1cca2f2b119c3d1eb8c6eb135f582edc72516095bb6be9a2d3b530d3aa3d639",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.buildservices/11.3.2/avalonia.buildservices.11.3.2.nupkg",
+        "sha512": "233f868e74ab91e56818004ad0aa7d0bb6e978044ddcf0061e373ada06a1846b17a82e94c777ab907ba484c1873d2212b47d3539d2694e89a415f1af047c3045",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.buildservices.0.0.29.nupkg"
+        "dest-filename": "avalonia.buildservices.11.3.2.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.desktop/11.2.3/avalonia.desktop.11.2.3.nupkg",
-        "sha512": "d4571946343ea7c19cf5ea7ed4dc9996eb6143522a043ee08910e12522646af63e75bae77d9fd58bf2231d58c4fc4a0e46d1f7b7fa4b9a4ff57e92a1e1de9bdf",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.desktop/11.3.12/avalonia.desktop.11.3.12.nupkg",
+        "sha512": "2a5c144645e51840953c822903bb9db9cd64d9bf8e3ab128a9e7ef731443a570075eecf6f1c5a7700a4836c223fb14223f1db08bd56c4c25c5cac48030872d38",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.desktop.11.2.3.nupkg"
+        "dest-filename": "avalonia.desktop.11.3.12.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.freedesktop/11.2.3/avalonia.freedesktop.11.2.3.nupkg",
-        "sha512": "5b2ca181dcfeb768ea9bf3ece7a445b4b0f80bbd54c2c36355bdde8a842c5f1385ae6896ccca1898bd01d43cc08c7b2a4ebfb0ca2204c21e681c69de849a1ace",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.freedesktop/11.3.12/avalonia.freedesktop.11.3.12.nupkg",
+        "sha512": "59fc260a98449b6be7e358824e598910b59d3b5f0781874336e49c15f768430964a0bbb4ed96dc98e90750bf491d6ad13a2bf68cc8f634c174b890e4cc2a8603",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.freedesktop.11.2.3.nupkg"
+        "dest-filename": "avalonia.freedesktop.11.3.12.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.native/11.2.3/avalonia.native.11.2.3.nupkg",
-        "sha512": "55b82bb16653841002bd1f6ad45e90c945c0b92976df7e5b4c6aa7dfe96aae18a2798c38f3e23b2586bc29c799912362d010233d29db9caa24c5f75fc2d6eeba",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.native/11.3.12/avalonia.native.11.3.12.nupkg",
+        "sha512": "c679ed66d8be99c59693d4d467388bffe7ee801ed140de0ea8c4fc6990f7a9848fb85659dd85b43cf3b63bfc083316a84034764c82d21e0031dbf376d196c8bf",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.native.11.2.3.nupkg"
+        "dest-filename": "avalonia.native.11.3.12.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.remote.protocol/11.2.3/avalonia.remote.protocol.11.2.3.nupkg",
-        "sha512": "94f5a03b3810a1c6df15e5f1c6bd95b32b99d13856e0270834e15cf0846966e6f3ed8175d7cad59723a1d00a0a11e4097eaf015597a95096728e5f9a2fd6443a",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.remote.protocol/11.3.12/avalonia.remote.protocol.11.3.12.nupkg",
+        "sha512": "64ab473d0c27846b4a0023cbc507a346d2a63ff62df41e1c96f2311507cce11e461a70f6c711b78ff1f6c49d0cb7a4d38d313531d84d2b2a2ffb3d16a11678f6",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.remote.protocol.11.2.3.nupkg"
+        "dest-filename": "avalonia.remote.protocol.11.3.12.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.skia/11.2.3/avalonia.skia.11.2.3.nupkg",
-        "sha512": "3a1fb97d0b24b774e464313d11bca01d05d06072e9642d65ff356e1a6d87dff7c1a067a64b0098a23e5e6a9fa26d837f2a5ba0aa144afa10e4542597eb07262b",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.skia/11.3.12/avalonia.skia.11.3.12.nupkg",
+        "sha512": "05a0b4d371fbf688b468a2cb21a619f84fd28e52d95d4a99e0c7e4166e85825733a5b80770ddfd5e08911cb8a76bcef74a3c0a204063befb95f7e141a0e3d52f",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.skia.11.2.3.nupkg"
+        "dest-filename": "avalonia.skia.11.3.12.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.themes.simple/11.2.3/avalonia.themes.simple.11.2.3.nupkg",
-        "sha512": "db2ee573a40fdf69c2967139db5c6e1b33fc1a241f5c4578d9583b4c2b2fd1fa0c6ae61e6c30f93289331d4e120701f1caeef19b6a7c133f4cd82f9fbf777cc8",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.themes.simple/11.3.12/avalonia.themes.simple.11.3.12.nupkg",
+        "sha512": "999053bc22baead6c100897c5b46189491326a28c0c64b462b5d98b3b6d4a17522a3c9055ba6db12dd5e174dec3d13a40ea3a72feb4a4b0e47ea7823b7c2bd9f",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.themes.simple.11.2.3.nupkg"
+        "dest-filename": "avalonia.themes.simple.11.3.12.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.win32/11.2.3/avalonia.win32.11.2.3.nupkg",
-        "sha512": "1a163f2342ec1f5de731ebeca8598735f0b4c236ec4dbd68056b8f9665206ba631e795e779147285f32b2165b5704a53221244137b0dae156f7302b3eaeb50ae",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.win32/11.3.12/avalonia.win32.11.3.12.nupkg",
+        "sha512": "6ecf6b67bb9738ae15044e5749ae1275113f9bd395e41100331c6c4cdcab3b57eb8d348a5969a6dea84e82b919f3133f50e4ce88e7767ac9687222af33a15392",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.win32.11.2.3.nupkg"
+        "dest-filename": "avalonia.win32.11.3.12.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.x11/11.2.3/avalonia.x11.11.2.3.nupkg",
-        "sha512": "cbac07377f5c424fcc49ee8ebfd0b128d7411825dfefc66164644673c8fd1dfd4ed00b510a06bd990c6cbd22cbdf7cc57f7ae35e84f9fdab57d6a08ce089f0b9",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.x11/11.3.12/avalonia.x11.11.3.12.nupkg",
+        "sha512": "035b9835b921433842990e77716a10eeebc8a1c9d4f606251a813eaea180f96713ded0d7552809e759c5cdc05982098dda02ee92519cea7c59bff0a61a384f94",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.x11.11.2.3.nupkg"
+        "dest-filename": "avalonia.x11.11.3.12.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp/7.3.0.3/harfbuzzsharp.7.3.0.3.nupkg",
-        "sha512": "bed625c58228c404f860fb3e247fb6ca3209c93fea62da498ba43419500bd40944b2e117f50f587f860101a6c6478ad1d18075f655376d1749d238d74b6a0bd3",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp/8.3.1.1/harfbuzzsharp.8.3.1.1.nupkg",
+        "sha512": "ed1d94447956fa595c4867fe3eeb4a7b67c97e00e0da5a72762362212cbf25e62be5936e59617c94a1cbd4e6bbd0ac902854d0d36866bd920ed6a85ae663ac8c",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.7.3.0.3.nupkg"
+        "dest-filename": "harfbuzzsharp.8.3.1.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.linux/7.3.0.3/harfbuzzsharp.nativeassets.linux.7.3.0.3.nupkg",
-        "sha512": "cf94e5693c4c475a702c342163f1ee28d2d9c3a13939a8334bb7133d13ffc5ed95d9dbb6145e7ac004cfd6e626a16280df7f1a4c7e3687569eced58b8890a1b5",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.linux/8.3.1.1/harfbuzzsharp.nativeassets.linux.8.3.1.1.nupkg",
+        "sha512": "4dbffeb5d07c377b5f6d7d54a658c6e272fa786869c4e6a6fdbf8bbf85f89d01a606ddfe240592f36ddd37807470f0546bbc7de9a6eb0508da15e91d14a95617",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.linux.7.3.0.3.nupkg"
+        "dest-filename": "harfbuzzsharp.nativeassets.linux.8.3.1.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.macos/7.3.0.3/harfbuzzsharp.nativeassets.macos.7.3.0.3.nupkg",
-        "sha512": "a6dac2eb2c536f25734e5358aaae9263f568871fa31169e816d8617c5b6e933d78e2956ea9e01ac37e0022bf243e63124956804b46f6a0d00826aa02320ef22b",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.macos/8.3.1.1/harfbuzzsharp.nativeassets.macos.8.3.1.1.nupkg",
+        "sha512": "063155862a999d07c01e4df3b2df2d23aa320c25ee62509b0bde657ec8797e0c6fe95fe4b29e9f6b2e9a0120dc76df431c547f7baf9faa19936c5a9eb78da2e6",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.macos.7.3.0.3.nupkg"
+        "dest-filename": "harfbuzzsharp.nativeassets.macos.8.3.1.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.webassembly/7.3.0.3/harfbuzzsharp.nativeassets.webassembly.7.3.0.3.nupkg",
-        "sha512": "87ad62fc8471b12ecce7284ff8f69fe681ae1010e6e44e6ac66807b061213d8b8f5537ff4fe34195107c6ba1bc3bff1c2db0abe7bd51520820e7b6f2addfdf63",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.webassembly/8.3.1.1/harfbuzzsharp.nativeassets.webassembly.8.3.1.1.nupkg",
+        "sha512": "746d52bf1820d897211982b466d274477dc2e698a97827cb6dc5303b2355ad9ec7929902d484be205282bec2ebaad2824952d7096ae3b03c4a9be5ee8384d9db",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.webassembly.7.3.0.3.nupkg"
+        "dest-filename": "harfbuzzsharp.nativeassets.webassembly.8.3.1.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.win32/7.3.0.3/harfbuzzsharp.nativeassets.win32.7.3.0.3.nupkg",
-        "sha512": "dd940d3b3085996b4e5961a0e42bb1a86daad360e3377602fafd60b0cb4d3d5ed9c3f4293a8551df75f38111b3a9f4dbbea4cb27b3e0632a6d48239b606d13c9",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.win32/8.3.1.1/harfbuzzsharp.nativeassets.win32.8.3.1.1.nupkg",
+        "sha512": "5bf6504c34f9040445d6f88d975896b289cb622b4de109761e721cb83e8d3301686eedd6a67a9dd5e4742feba6d5ed1d106932372f43159926712ad6f1e02af3",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.win32.7.3.0.3.nupkg"
+        "dest-filename": "harfbuzzsharp.nativeassets.win32.8.3.1.1.nupkg"
     },
     {
         "type": "file",
@@ -120,17 +120,17 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/9.0.0/microsoft.aspnetcore.app.runtime.linux-x64.9.0.0.nupkg",
-        "sha512": "6a1d62af51047864ac8630242a9f257dd978e163985c566673276f3919d022cdc878a0a4c2141364d92064ec22793d4db460744cb6dcd21d45495eac511967b9",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/9.0.11/microsoft.aspnetcore.app.runtime.linux-x64.9.0.11.nupkg",
+        "sha512": "1565381f3b055a367799c32eca9ba444d7ac6d679088b7fe2f48034bdff7b133542f121771b671871ce5bb1528e137f81352a05ff1ba2d0ededb666a8fecf3c4",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.9.0.0.nupkg"
+        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.9.0.11.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.dotnet.ilcompiler/9.0.0/microsoft.dotnet.ilcompiler.9.0.0.nupkg",
-        "sha512": "5655e96822f8fd906ad6f956ff9f1bc26f6135dd8c5d18b03d786f7dc96c2cc2768fa7c969a5f60260775ec80859895a81e5b4158d6ff909b286b21f98a246c6",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.dotnet.ilcompiler/9.0.11/microsoft.dotnet.ilcompiler.9.0.11.nupkg",
+        "sha512": "823f7e02459265c9a7fedefd88761595189dcb582326aba2c27107270774d62822e924d822cb941ca94d2f542aadaa2706d55ba3f7300ae77c692378bfc8d0dd",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.dotnet.ilcompiler.9.0.0.nupkg"
+        "dest-filename": "microsoft.dotnet.ilcompiler.9.0.11.nupkg"
     },
     {
         "type": "file",
@@ -148,24 +148,24 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.net.illink.tasks/9.0.0/microsoft.net.illink.tasks.9.0.0.nupkg",
-        "sha512": "c60d7deae05f9d498995ce5a8b37d38b9f3c332aee23d1e5bdaaa3de631bc7527d19fa45fadde075647ab8a6c7d25556f68c7327b1605fb356644663df78f46a",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.net.illink.tasks/9.0.11/microsoft.net.illink.tasks.9.0.11.nupkg",
+        "sha512": "6a035c092a7a2a776d76300acc2eee0646512d0b958cf28ba1af25827584eb540b9ed84e0ed20ddf29722291bf0ecfa5520dfb3417085c2ea041dbbb13afd500",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.net.illink.tasks.9.0.0.nupkg"
+        "dest-filename": "microsoft.net.illink.tasks.9.0.11.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.win-x64/9.0.0/microsoft.netcore.app.host.win-x64.9.0.0.nupkg",
-        "sha512": "ed2107bef0cf698856c8d85402ead9a2ed683eb4e089b9f693d4415be7da9529665cfab9008a8d8b810e0c951bc9d735432c83daf423455817be117a689f6cd5",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.win-x64/9.0.11/microsoft.netcore.app.host.win-x64.9.0.11.nupkg",
+        "sha512": "4a1d64fca01be7ae30ca41b9c1568dbd6a230b482b5d0f5a5adcb960e010adfebf460b165815667486f9f59dec735cc7f570f230a63c3044e8241d75af57e1a8",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.host.win-x64.9.0.0.nupkg"
+        "dest-filename": "microsoft.netcore.app.host.win-x64.9.0.11.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/9.0.0/microsoft.netcore.app.runtime.linux-x64.9.0.0.nupkg",
-        "sha512": "b53da3f97f2c6899fd27ede233a328270bf99040215b2bb03de6598a9ab6eba603225c04696d850e3a160892552c2def08389d1e59d34fa20a52ffcb30a2a958",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/9.0.11/microsoft.netcore.app.runtime.linux-x64.9.0.11.nupkg",
+        "sha512": "645d28c1fea64dcde4c222d15e2b9bfd69a63f0e4b468f099e1b0c8520fcdf88a644d4873c59bbbd8e6aab3dcbd3d4b6fe5a0ef49836a809952cd4d03bc8d08b",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.runtime.linux-x64.9.0.0.nupkg"
+        "dest-filename": "microsoft.netcore.app.runtime.linux-x64.9.0.11.nupkg"
     },
     {
         "type": "file",
@@ -176,24 +176,24 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.linux-x64.microsoft.dotnet.ilcompiler/9.0.0/runtime.linux-x64.microsoft.dotnet.ilcompiler.9.0.0.nupkg",
-        "sha512": "9bdad0c876bc93ab661bd655d89c9762a1bca35804170f2e87c98fee544a59eb40d5c7978cf7d9504c0a0573316beef8f46d842e26cbebde982f6618f99f82d0",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.linux-x64.microsoft.dotnet.ilcompiler/9.0.11/runtime.linux-x64.microsoft.dotnet.ilcompiler.9.0.11.nupkg",
+        "sha512": "d77dd50fbb3679d5bd08db8e2722b27389c233d2fbc8e4aef736e2b01c6382dc0104a1f90f694d75d21fc6767856425e1031415ff8daafb77c6981e1668f150f",
         "dest": "nuget-sources",
-        "dest-filename": "runtime.linux-x64.microsoft.dotnet.ilcompiler.9.0.0.nupkg"
+        "dest-filename": "runtime.linux-x64.microsoft.dotnet.ilcompiler.9.0.11.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.win-x64.microsoft.dotnet.ilcompiler/9.0.0/runtime.win-x64.microsoft.dotnet.ilcompiler.9.0.0.nupkg",
-        "sha512": "3f9f5a47d543f468c8ece34000ad525631097d91090a92c5a3d0952def2b691766ab531683f790d6c5d1d80479d063e672248206922af2b0c06192ec0a22f1eb",
+        "url": "https://api.nuget.org/v3-flatcontainer/runtime.win-x64.microsoft.dotnet.ilcompiler/9.0.11/runtime.win-x64.microsoft.dotnet.ilcompiler.9.0.11.nupkg",
+        "sha512": "a1c50fc2fbdfb9dde0479f38aa5c7c63c45deb6c41e04758a18320a2cd80acb7c0ee183b059f595d8ead212434ada69bbd4e5acc4ce2f6d07a41b0dfb6a827fa",
         "dest": "nuget-sources",
-        "dest-filename": "runtime.win-x64.microsoft.dotnet.ilcompiler.9.0.0.nupkg"
+        "dest-filename": "runtime.win-x64.microsoft.dotnet.ilcompiler.9.0.11.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/sharpcompress/0.38.0/sharpcompress.0.38.0.nupkg",
-        "sha512": "9107c6cf7b5d0633a31496634c388e41870e5f25a99c4eaa44f0bb5e1ffa24307c186ef63e6b54983571cde9f0558a44f51c6b743943162668beb6dadd438278",
+        "url": "https://api.nuget.org/v3-flatcontainer/sharpcompress/0.46.3/sharpcompress.0.46.3.nupkg",
+        "sha512": "93d2723df435ab07b54ea58872919fa62848d39dcf6569c3e85cf187025f004aad1f76a3c56db9cae1d2bbc8259303cc54112a30bd7ed75b42f4a806b0beeaa3",
         "dest": "nuget-sources",
-        "dest-filename": "sharpcompress.0.38.0.nupkg"
+        "dest-filename": "sharpcompress.0.46.3.nupkg"
     },
     {
         "type": "file",
@@ -239,16 +239,9 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/tmds.dbus.protocol/0.20.0/tmds.dbus.protocol.0.20.0.nupkg",
-        "sha512": "602cf251f034d41a4feef63f0d77c3005553f88abd5ba9cf941d0f731369aa1c0a8844e89686f7fd3a1ad8e02068b5c3b4dd3e719fdb40cb603b9ca3b0e22e8e",
+        "url": "https://api.nuget.org/v3-flatcontainer/tmds.dbus.protocol/0.21.2/tmds.dbus.protocol.0.21.2.nupkg",
+        "sha512": "01e55dad6b1b3060cf3022727231db50ae1272f8d71112783f9213fe1adc930cd8ee60227f7b5569711287858086a9e882beda137ebd08c279fda23c89af25f2",
         "dest": "nuget-sources",
-        "dest-filename": "tmds.dbus.protocol.0.20.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/zstdsharp.port/0.8.1/zstdsharp.port.0.8.1.nupkg",
-        "sha512": "b1efdf27e2c4ef13387695318701d2f0344e4195b364cb373061766dc8269d7276adc0a2282c80d900e987bb2812b62884725878409abeeba5f796cd81395d85",
-        "dest": "nuget-sources",
-        "dest-filename": "zstdsharp.port.0.8.1.nupkg"
+        "dest-filename": "tmds.dbus.protocol.0.21.2.nupkg"
     }
 ]


### PR DESCRIPTION
Updates Nexus LU Launcher to V.2.3.1 ([GitHub release](https://github.com/TheNexusAvenger/Nexus-LU-Launcher/releases/tag/V.2.3.1)).